### PR TITLE
Plot Route: Correct color argument warning

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -293,7 +293,7 @@ def plot_graph_route(
     # scatterplot origin and destination points (first/last nodes in route)
     x = (G.nodes[route[0]]["x"], G.nodes[route[-1]]["x"])
     y = (G.nodes[route[0]]["y"], G.nodes[route[-1]]["y"])
-    ax.scatter(x, y, s=orig_dest_size, c=route_color, alpha=route_alpha, edgecolor="none")
+    ax.scatter(x, y, s=orig_dest_size, color=route_color, alpha=route_alpha, edgecolor="none")
 
     # assemble the route edge geometries' x and y coords then plot the line
     x = []
@@ -310,7 +310,7 @@ def plot_graph_route(
             # otherwise, the edge is a straight line from node to node
             x.extend((G.nodes[u]["x"], G.nodes[v]["x"]))
             y.extend((G.nodes[u]["y"], G.nodes[v]["y"]))
-    ax.plot(x, y, c=route_color, lw=route_linewidth, alpha=route_alpha)
+    ax.plot(x, y, color=route_color, lw=route_linewidth, alpha=route_alpha)
 
     # save and show the figure as specified, passing relevant kwargs
     sas_kwargs = {"save", "show", "close", "filepath", "file_format", "dpi"}


### PR DESCRIPTION
Matplotlib throws a warning when colors are provided as a 1D array with the "c" argument.  This is corrected by specifying the "color" argument in lieu of "c".


```python
import osmnx as ox
ox.config(use_cache=True, log_console=True)

G = ox.graph_from_place('Munich, Germany', network_type='drive')
route1 = ox.shortest_path(G, 20461931, 75901933, weight=None)

orig = ox.get_nearest_node(G, (48.1336081,  11.58172095))
dest = ox.get_nearest_node(G, (48.17822992, 11.53754219))
route2 = ox.shortest_path(G, orig, dest, weight='travel_time')

colors = [[0.1,0.25,0.5],[0.5,0.15,0.1]]
ox.plot_graph_routes(G,[route1, route2],colors)
```

```
*c* argument looks like a single numeric RGB or RGBA sequence, which should be avoided as value-mapping will have precedence in case its length matches with *x* & *y*.  Please use the *color* keyword-argument or provide a 2D array with a single row if you intend to specify the same RGB or RGBA value for all points.
*c* argument looks like a single numeric RGB or RGBA sequence, which should be avoided as value-mapping will have precedence in case its length matches with *x* & *y*.  Please use the *color* keyword-argument or provide a 2D array with a single row if you intend to specify the same RGB or RGBA value for all points.
```

Running the same code with this patch removes the warning.